### PR TITLE
Handle long text with opt-in scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
       .phrase-item-container {
         display: flex; /* Arrange phrase button and delete button side-by-side */
         align-items: stretch; /* Make buttons same height */
+        min-width: 0;
+        max-width: 100%;
         border-radius: 0.5rem; /* Rounded corners for the container */
         overflow: hidden; /* Clip corners */
         box-shadow:
@@ -65,16 +67,78 @@
       .phrase-button {
         transition: background-color 0.15s ease-in-out;
         flex-grow: 1; /* Allow button to take available space */
+        min-width: 0;
         /* Allow button height to grow with content */
         height: auto;
-        /* Ensure text wraps within the button */
-        white-space: normal;
-        word-wrap: break-word;
         text-align: left; /* Keep text aligned left */
         /* Remove individual shadow, applied to container now */
         /* Remove individual rounded corners on the right */
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
+      }
+      .phrase-label-wrap {
+        display: block;
+        min-width: 0;
+        overflow: hidden;
+        flex: 1 1 auto;
+      }
+      .phrase-label-track {
+        display: inline-flex;
+        align-items: center;
+        min-width: max-content;
+        white-space: nowrap;
+      }
+      .phrase-label-text,
+      .phrase-label-clone {
+        flex: 0 0 auto;
+      }
+      .phrase-label-gap {
+        display: none;
+        flex: 0 0 var(--marquee-gap, 2rem);
+        width: var(--marquee-gap, 2rem);
+      }
+      .phrase-label-clone {
+        display: none;
+      }
+      .phrase-button.is-overflowing .phrase-label-track {
+        animation: phrase-marquee var(--marquee-duration, 10s) linear infinite;
+      }
+      .phrase-button.is-overflowing .phrase-label-gap,
+      .phrase-button.is-overflowing .phrase-label-clone {
+        display: inline-block;
+      }
+      .phrase-button.is-overflowing:hover .phrase-label-track,
+      .phrase-button.is-overflowing:focus-visible .phrase-label-track {
+        animation-play-state: paused;
+      }
+      @keyframes phrase-marquee {
+        from {
+          transform: translateX(0);
+        }
+        to {
+          transform: translateX(calc(-1 * var(--marquee-distance, 0px)));
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .phrase-button.is-overflowing .phrase-label-track {
+          animation: none;
+        }
+        .phrase-label-wrap {
+          overflow: visible;
+        }
+        .phrase-label-track {
+          min-width: 0;
+          display: block;
+          white-space: normal;
+        }
+        .phrase-label-text {
+          overflow-wrap: anywhere;
+          word-break: break-word;
+        }
+        .phrase-label-gap,
+        .phrase-label-clone {
+          display: none !important;
+        }
       }
 
       /* Styling for the separate delete button */
@@ -172,6 +236,7 @@
       const clearAllButton = document.getElementById("clearAllButton");
       const sortByUseToggle = document.getElementById("sortByUseToggle");
       const showUsageToggle = document.getElementById("showUsageToggle");
+      let overflowMeasureFrame = 0;
 
       // --- Constants ---
       const STORAGE_KEY = "omniTextPhrases"; // kept same for backwards compatibility
@@ -281,6 +346,43 @@
         fullScreenText.textContent = ""; // Clear text
       }
 
+      function syncOverflowingPhraseButtons() {
+        const phraseButtons = textListDiv.querySelectorAll(".phrase-button");
+        phraseButtons.forEach((button) => {
+          const labelWrap = button.querySelector(".phrase-label-wrap");
+          const labelText = button.querySelector(".phrase-label-text");
+          const labelClone = button.querySelector(".phrase-label-clone");
+          if (!labelWrap || !labelText || !labelClone) return;
+
+          button.classList.remove("is-overflowing");
+          button.style.removeProperty("--marquee-gap");
+          button.style.removeProperty("--marquee-distance");
+          button.style.removeProperty("--marquee-duration");
+          labelClone.textContent = "";
+
+          const overflows = labelText.scrollWidth > labelWrap.clientWidth + 1;
+          if (!overflows) return;
+
+          const gap = Math.max(24, Math.round(labelWrap.clientWidth * 0.12));
+          const distance = labelText.scrollWidth + gap;
+          const duration = Math.max(6, Math.min(18, distance / 32));
+
+          labelClone.textContent = labelText.textContent;
+          button.style.setProperty("--marquee-gap", `${gap}px`);
+          button.style.setProperty("--marquee-distance", `${distance}px`);
+          button.style.setProperty("--marquee-duration", `${duration}s`);
+          button.classList.add("is-overflowing");
+        });
+      }
+
+      function scheduleOverflowSync() {
+        if (overflowMeasureFrame) cancelAnimationFrame(overflowMeasureFrame);
+        overflowMeasureFrame = requestAnimationFrame(() => {
+          overflowMeasureFrame = 0;
+          syncOverflowingPhraseButtons();
+        });
+      }
+
       /**
        * Increment usage count for a phrase and persist; refresh list (keeps sort up-to-date)
        */
@@ -338,8 +440,14 @@
             `Show phrase: ${phrase.text}`,
           );
           phraseButton.innerHTML = `
-            <div class="flex items-start justify-between gap-2">
-              <span class="block break-anywhere">${escapeHtml(phrase.text)}</span>
+            <div class="flex items-center justify-between gap-2 min-w-0">
+              <span class="phrase-label-wrap">
+                <span class="phrase-label-track">
+                  <span class="phrase-label-text">${escapeHtml(phrase.text)}</span>
+                  <span class="phrase-label-gap" aria-hidden="true"></span>
+                  <span class="phrase-label-clone" aria-hidden="true"></span>
+                </span>
+              </span>
               ${showUsage ? `<span class=\"shrink-0 text-xs font-semibold bg-black/20 rounded px-1\">×${phrase.count}</span>` : ""}
             </div>`;
           phraseButton.onclick = () => showFullScreen(phrase.text);
@@ -358,6 +466,8 @@
           itemContainer.appendChild(deleteBtn);
           textListDiv.appendChild(itemContainer);
         });
+
+        scheduleOverflowSync();
       }
 
       /** Adds a new phrase to the list (dedupe by exact text). */
@@ -430,11 +540,15 @@
         saveSettings(settings);
         renderPhraseButtons();
       });
+      window.addEventListener("resize", scheduleOverflowSync);
 
       // --- Initial Load ---
       document.addEventListener("DOMContentLoaded", () => {
         updateSettingsUI();
         renderPhraseButtons();
+        if (document.fonts && document.fonts.ready) {
+          document.fonts.ready.then(scheduleOverflowSync);
+        }
       });
 
       // --- PWA Service Worker Registration ---

--- a/index.html
+++ b/index.html
@@ -79,18 +79,18 @@
       .phrase-label-wrap {
         display: block;
         min-width: 0;
-        overflow: hidden;
+        overflow: visible;
         flex: 1 1 auto;
       }
       .phrase-label-track {
-        display: inline-flex;
-        align-items: center;
-        min-width: max-content;
-        white-space: nowrap;
+        display: block;
+        min-width: 0;
+        white-space: normal;
       }
-      .phrase-label-text,
-      .phrase-label-clone {
-        flex: 0 0 auto;
+      .phrase-label-text {
+        display: block;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
       .phrase-label-gap {
         display: none;
@@ -100,15 +100,32 @@
       .phrase-label-clone {
         display: none;
       }
-      .phrase-button.is-overflowing .phrase-label-track {
+      .phrase-button.measuring-marquee .phrase-label-wrap,
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-wrap {
+        overflow: hidden;
+      }
+      .phrase-button.measuring-marquee .phrase-label-track,
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-track {
+        display: inline-flex;
+        align-items: center;
+        min-width: max-content;
+        white-space: nowrap;
+      }
+      .phrase-button.measuring-marquee .phrase-label-text,
+      .phrase-button.measuring-marquee .phrase-label-clone,
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-text,
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-clone {
+        flex: 0 0 auto;
+      }
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-track {
         animation: phrase-marquee var(--marquee-duration, 10s) linear infinite;
       }
-      .phrase-button.is-overflowing .phrase-label-gap,
-      .phrase-button.is-overflowing .phrase-label-clone {
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-gap,
+      .phrase-button.marquee-enabled.is-overflowing .phrase-label-clone {
         display: inline-block;
       }
-      .phrase-button.is-overflowing:hover .phrase-label-track,
-      .phrase-button.is-overflowing:focus-visible .phrase-label-track {
+      .phrase-button.marquee-enabled.is-overflowing:hover .phrase-label-track,
+      .phrase-button.marquee-enabled.is-overflowing:focus-visible .phrase-label-track {
         animation-play-state: paused;
       }
       @keyframes phrase-marquee {
@@ -120,18 +137,16 @@
         }
       }
       @media (prefers-reduced-motion: reduce) {
-        .phrase-button.is-overflowing .phrase-label-track {
-          animation: none;
-        }
-        .phrase-label-wrap {
+        .phrase-button.marquee-enabled.is-overflowing .phrase-label-wrap {
           overflow: visible;
         }
-        .phrase-label-track {
+        .phrase-button.marquee-enabled.is-overflowing .phrase-label-track {
+          animation: none;
           min-width: 0;
           display: block;
           white-space: normal;
         }
-        .phrase-label-text {
+        .phrase-button.marquee-enabled.is-overflowing .phrase-label-text {
           overflow-wrap: anywhere;
           word-break: break-word;
         }
@@ -193,9 +208,9 @@
         </button>
       </div>
 
-      <div class="flex items-center justify-between mb-4">
+      <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
         <h2 class="text-xl font-semibold text-gray-700">Saved Phrases</h2>
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
           <label
             class="flex items-center gap-2 text-sm text-gray-600"
             title="Sort by most used, then recent"
@@ -209,6 +224,13 @@
           >
             <input type="checkbox" id="showUsageToggle" class="h-4 w-4" />
             <span>Show usage</span>
+          </label>
+          <label
+            class="flex items-center gap-2 text-sm text-gray-600"
+            title="Scroll overflowing saved phrases"
+          >
+            <input type="checkbox" id="marqueeToggle" class="h-4 w-4" />
+            <span>Scroll long text</span>
           </label>
         </div>
       </div>
@@ -236,6 +258,7 @@
       const clearAllButton = document.getElementById("clearAllButton");
       const sortByUseToggle = document.getElementById("sortByUseToggle");
       const showUsageToggle = document.getElementById("showUsageToggle");
+      const marqueeToggle = document.getElementById("marqueeToggle");
       let overflowMeasureFrame = 0;
 
       // --- Constants ---
@@ -260,18 +283,20 @@
           return {
             sortByUse: parsed.sortByUse ?? true,
             showUsage: parsed.showUsage ?? true,
+            enableMarquee: parsed.enableMarquee ?? false,
           };
         } catch (_) {
-          return { sortByUse: true, showUsage: true };
+          return { sortByUse: true, showUsage: true, enableMarquee: false };
         }
       }
       function saveSettings(s) {
         localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
       }
       function updateSettingsUI() {
-        const { sortByUse, showUsage } = getSettings();
+        const { sortByUse, showUsage, enableMarquee } = getSettings();
         if (sortByUseToggle) sortByUseToggle.checked = !!sortByUse;
         if (showUsageToggle) showUsageToggle.checked = !!showUsage;
+        if (marqueeToggle) marqueeToggle.checked = !!enableMarquee;
       }
 
       // --- Data Access Layer (with migration) ---
@@ -347,6 +372,7 @@
       }
 
       function syncOverflowingPhraseButtons() {
+        const { enableMarquee } = getSettings();
         const phraseButtons = textListDiv.querySelectorAll(".phrase-button");
         phraseButtons.forEach((button) => {
           const labelWrap = button.querySelector(".phrase-label-wrap");
@@ -354,23 +380,32 @@
           const labelClone = button.querySelector(".phrase-label-clone");
           if (!labelWrap || !labelText || !labelClone) return;
 
+          button.classList.remove("measuring-marquee");
+          button.classList.remove("marquee-enabled");
           button.classList.remove("is-overflowing");
           button.style.removeProperty("--marquee-gap");
           button.style.removeProperty("--marquee-distance");
           button.style.removeProperty("--marquee-duration");
           labelClone.textContent = "";
 
-          const overflows = labelText.scrollWidth > labelWrap.clientWidth + 1;
+          if (!enableMarquee) return;
+
+          button.classList.add("measuring-marquee");
+          const textWidth = Math.ceil(labelText.getBoundingClientRect().width);
+          const availableWidth = Math.floor(labelWrap.clientWidth);
+          const overflows = textWidth > availableWidth + 1;
+          button.classList.remove("measuring-marquee");
           if (!overflows) return;
 
           const gap = Math.max(24, Math.round(labelWrap.clientWidth * 0.12));
-          const distance = labelText.scrollWidth + gap;
+          const distance = textWidth + gap;
           const duration = Math.max(6, Math.min(18, distance / 32));
 
           labelClone.textContent = labelText.textContent;
           button.style.setProperty("--marquee-gap", `${gap}px`);
           button.style.setProperty("--marquee-distance", `${distance}px`);
           button.style.setProperty("--marquee-duration", `${duration}s`);
+          button.classList.add("marquee-enabled");
           button.classList.add("is-overflowing");
         });
       }
@@ -537,6 +572,12 @@
       showUsageToggle.addEventListener("change", (e) => {
         const settings = getSettings();
         settings.showUsage = !!e.target.checked;
+        saveSettings(settings);
+        renderPhraseButtons();
+      });
+      marqueeToggle.addEventListener("change", (e) => {
+        const settings = getSettings();
+        settings.enableMarquee = !!e.target.checked;
         saveSettings(settings);
         renderPhraseButtons();
       });

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
 
         const gap = Math.max(48, Math.round(availableHeight * 0.12));
         const distance = textHeight + gap;
-        const duration = Math.max(12, distance / 30);
+        const duration = Math.max(9, distance / 50);
 
         fullScreenTextGap.style.height = `${gap}px`;
         fullScreenTextClone.textContent = fullScreenText.textContent;

--- a/index.html
+++ b/index.html
@@ -271,28 +271,56 @@
         class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between"
       >
         <h2 class="text-xl font-semibold text-gray-700">Saved Phrases</h2>
-        <div class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
-          <label
-            class="flex items-center gap-2 text-sm text-gray-600"
-            title="Sort by most used, then recent"
+        <div class="flex flex-col gap-3 sm:items-end">
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
+            <label
+              class="flex items-center gap-2 text-sm text-gray-600"
+              title="Sort by most used, then recent"
+            >
+              <input type="checkbox" id="sortByUseToggle" class="h-4 w-4" />
+              <span>Sort by usage</span>
+            </label>
+            <label
+              class="flex items-center gap-2 text-sm text-gray-600"
+              title="Show or hide usage badges"
+            >
+              <input type="checkbox" id="showUsageToggle" class="h-4 w-4" />
+              <span>Show usage</span>
+            </label>
+            <label
+              class="flex items-center gap-2 text-sm text-gray-600"
+              title="Scroll overflowing saved phrases"
+            >
+              <input type="checkbox" id="marqueeToggle" class="h-4 w-4" />
+              <span>Scroll long text</span>
+            </label>
+          </div>
+          <div
+            id="scrollSpeedControls"
+            class="hidden w-full rounded-lg border border-gray-200 bg-gray-50 p-3 sm:max-w-sm"
           >
-            <input type="checkbox" id="sortByUseToggle" class="h-4 w-4" />
-            <span>Sort by usage</span>
-          </label>
-          <label
-            class="flex items-center gap-2 text-sm text-gray-600"
-            title="Show or hide usage badges"
-          >
-            <input type="checkbox" id="showUsageToggle" class="h-4 w-4" />
-            <span>Show usage</span>
-          </label>
-          <label
-            class="flex items-center gap-2 text-sm text-gray-600"
-            title="Scroll overflowing saved phrases"
-          >
-            <input type="checkbox" id="marqueeToggle" class="h-4 w-4" />
-            <span>Scroll long text</span>
-          </label>
+            <div class="flex items-center justify-between gap-3 text-sm text-gray-600">
+              <label for="scrollSpeedSlider" class="font-medium text-gray-700">
+                Scroll speed
+              </label>
+              <span id="scrollSpeedValue" class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Normal
+              </span>
+            </div>
+            <input
+              type="range"
+              id="scrollSpeedSlider"
+              min="1"
+              max="5"
+              step="1"
+              value="3"
+              class="mt-3 w-full accent-blue-500"
+            />
+            <div class="mt-1 flex justify-between text-xs text-gray-500">
+              <span>Slower</span>
+              <span>Faster</span>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -338,6 +366,9 @@
       const sortByUseToggle = document.getElementById("sortByUseToggle");
       const showUsageToggle = document.getElementById("showUsageToggle");
       const marqueeToggle = document.getElementById("marqueeToggle");
+      const scrollSpeedControls = document.getElementById("scrollSpeedControls");
+      const scrollSpeedSlider = document.getElementById("scrollSpeedSlider");
+      const scrollSpeedValue = document.getElementById("scrollSpeedValue");
       let overflowMeasureFrame = 0;
       let fullScreenMeasureFrame = 0;
 
@@ -364,19 +395,41 @@
             sortByUse: parsed.sortByUse ?? true,
             showUsage: parsed.showUsage ?? true,
             enableMarquee: parsed.enableMarquee ?? false,
+            scrollSpeed: parsed.scrollSpeed ?? 3,
           };
         } catch (_) {
-          return { sortByUse: true, showUsage: true, enableMarquee: false };
+          return {
+            sortByUse: true,
+            showUsage: true,
+            enableMarquee: false,
+            scrollSpeed: 3,
+          };
         }
       }
       function saveSettings(s) {
         localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
       }
+      function getScrollSpeedLabel(scrollSpeed) {
+        if (scrollSpeed <= 1) return "Slow";
+        if (scrollSpeed === 2) return "Relaxed";
+        if (scrollSpeed === 3) return "Normal";
+        if (scrollSpeed === 4) return "Fast";
+        return "Faster";
+      }
+      function getScrollSpeedFactor(scrollSpeed) {
+        const speed = Math.max(1, Math.min(5, Number(scrollSpeed) || 3));
+        return 0.7 + (speed - 1) * 0.2;
+      }
       function updateSettingsUI() {
-        const { sortByUse, showUsage, enableMarquee } = getSettings();
+        const { sortByUse, showUsage, enableMarquee, scrollSpeed } = getSettings();
         if (sortByUseToggle) sortByUseToggle.checked = !!sortByUse;
         if (showUsageToggle) showUsageToggle.checked = !!showUsage;
         if (marqueeToggle) marqueeToggle.checked = !!enableMarquee;
+        if (scrollSpeedSlider) scrollSpeedSlider.value = String(scrollSpeed);
+        if (scrollSpeedValue)
+          scrollSpeedValue.textContent = getScrollSpeedLabel(scrollSpeed);
+        if (scrollSpeedControls)
+          scrollSpeedControls.classList.toggle("hidden", !enableMarquee);
       }
 
       // --- Data Access Layer (with migration) ---
@@ -460,7 +513,7 @@
       }
 
       function syncFullScreenMarquee() {
-        const { enableMarquee } = getSettings();
+        const { enableMarquee, scrollSpeed } = getSettings();
         fullScreenDisplay.classList.remove("measuring-scroll");
         fullScreenDisplay.classList.remove("vertical-scroll-enabled");
         fullScreenDisplay.classList.remove("is-overflowing");
@@ -488,7 +541,10 @@
 
         const gap = Math.max(48, Math.round(availableHeight * 0.12));
         const distance = textHeight + gap;
-        const duration = Math.max(9, distance / 50);
+        const duration = Math.max(
+          7,
+          (distance / 50) / getScrollSpeedFactor(scrollSpeed),
+        );
 
         fullScreenTextGap.style.height = `${gap}px`;
         fullScreenTextClone.textContent = fullScreenText.textContent;
@@ -514,7 +570,7 @@
       }
 
       function syncOverflowingPhraseButtons() {
-        const { enableMarquee } = getSettings();
+        const { enableMarquee, scrollSpeed } = getSettings();
         const phraseButtons = textListDiv.querySelectorAll(".phrase-button");
         phraseButtons.forEach((button) => {
           const labelWrap = button.querySelector(".phrase-label-wrap");
@@ -541,7 +597,10 @@
 
           const gap = Math.max(24, Math.round(labelWrap.clientWidth * 0.12));
           const distance = textWidth + gap;
-          const duration = Math.max(8, distance / 40);
+          const duration = Math.max(
+            6,
+            (distance / 40) / getScrollSpeedFactor(scrollSpeed),
+          );
 
           labelClone.textContent = labelText.textContent;
           button.style.setProperty("--marquee-gap", `${gap}px`);
@@ -721,6 +780,15 @@
         const settings = getSettings();
         settings.enableMarquee = !!e.target.checked;
         saveSettings(settings);
+        updateSettingsUI();
+        renderPhraseButtons();
+        scheduleFullScreenMarquee();
+      });
+      scrollSpeedSlider.addEventListener("input", (e) => {
+        const settings = getSettings();
+        settings.scrollSpeed = Number(e.target.value);
+        saveSettings(settings);
+        updateSettingsUI();
         renderPhraseButtons();
         scheduleFullScreenMarquee();
       });

--- a/index.html
+++ b/index.html
@@ -42,6 +42,47 @@
         opacity: 1;
         visibility: visible;
       }
+      #fullScreenTextWrap {
+        width: 100%;
+        max-width: 100%;
+        max-height: 100%;
+        overflow: visible;
+      }
+      #fullScreenTextTrack {
+        display: block;
+        min-width: 0;
+        white-space: normal;
+      }
+      #fullScreenText,
+      #fullScreenTextClone {
+        display: block;
+      }
+      #fullScreenTextGap,
+      #fullScreenTextClone {
+        display: none;
+      }
+      #fullScreenDisplay.measuring-scroll #fullScreenTextWrap,
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextWrap {
+        overflow: hidden;
+      }
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextTrack {
+        animation: full-screen-vertical-scroll
+          var(--full-screen-scroll-duration, 14s) linear infinite;
+      }
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextGap,
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextClone {
+        display: block;
+      }
+      @keyframes full-screen-vertical-scroll {
+        from {
+          transform: translateY(0);
+        }
+        to {
+          transform: translateY(
+            calc(-1 * var(--full-screen-scroll-distance, 0px))
+          );
+        }
+      }
 
       /* Robust long-word wrapping utility */
       .break-anywhere {
@@ -138,6 +179,23 @@
         }
       }
       @media (prefers-reduced-motion: reduce) {
+        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextWrap {
+          overflow: visible;
+        }
+        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextTrack {
+          animation: none;
+          min-width: 0;
+          display: block;
+          white-space: normal;
+        }
+        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenText {
+          overflow-wrap: anywhere;
+          word-break: break-word;
+        }
+        #fullScreenTextGap,
+        #fullScreenTextClone {
+          display: none !important;
+        }
         .phrase-button.marquee-enabled.is-overflowing .phrase-label-wrap {
           overflow: visible;
         }
@@ -248,7 +306,17 @@
     </div>
 
     <div id="fullScreenDisplay">
-      <span id="fullScreenText" class="break-anywhere"></span>
+      <div id="fullScreenTextWrap">
+        <div id="fullScreenTextTrack">
+          <span id="fullScreenText" class="break-anywhere"></span>
+          <span id="fullScreenTextGap" aria-hidden="true"></span>
+          <span
+            id="fullScreenTextClone"
+            class="break-anywhere"
+            aria-hidden="true"
+          ></span>
+        </div>
+      </div>
     </div>
 
     <script>
@@ -257,12 +325,21 @@
       const addButton = document.getElementById("addButton");
       const textListDiv = document.getElementById("textList");
       const fullScreenDisplay = document.getElementById("fullScreenDisplay");
+      const fullScreenTextWrap = document.getElementById("fullScreenTextWrap");
+      const fullScreenTextTrack = document.getElementById(
+        "fullScreenTextTrack",
+      );
       const fullScreenText = document.getElementById("fullScreenText");
+      const fullScreenTextGap = document.getElementById("fullScreenTextGap");
+      const fullScreenTextClone = document.getElementById(
+        "fullScreenTextClone",
+      );
       const clearAllButton = document.getElementById("clearAllButton");
       const sortByUseToggle = document.getElementById("sortByUseToggle");
       const showUsageToggle = document.getElementById("showUsageToggle");
       const marqueeToggle = document.getElementById("marqueeToggle");
       let overflowMeasureFrame = 0;
+      let fullScreenMeasureFrame = 0;
 
       // --- Constants ---
       const STORAGE_KEY = "omniTextPhrases"; // kept same for backwards compatibility
@@ -366,12 +443,74 @@
 
         fullScreenText.textContent = text;
         fullScreenDisplay.classList.add("visible");
+        scheduleFullScreenMarquee();
       }
 
       /** Hides the full-screen display. */
       function hideFullScreen() {
         fullScreenDisplay.classList.remove("visible");
+        fullScreenDisplay.classList.remove("measuring-scroll");
+        fullScreenDisplay.classList.remove("vertical-scroll-enabled");
+        fullScreenDisplay.classList.remove("is-overflowing");
+        fullScreenDisplay.style.removeProperty("--full-screen-scroll-distance");
+        fullScreenDisplay.style.removeProperty("--full-screen-scroll-duration");
+        fullScreenTextGap.style.removeProperty("height");
+        fullScreenTextClone.textContent = "";
         fullScreenText.textContent = ""; // Clear text
+      }
+
+      function syncFullScreenMarquee() {
+        const { enableMarquee } = getSettings();
+        fullScreenDisplay.classList.remove("measuring-scroll");
+        fullScreenDisplay.classList.remove("vertical-scroll-enabled");
+        fullScreenDisplay.classList.remove("is-overflowing");
+        fullScreenDisplay.style.removeProperty("--full-screen-scroll-distance");
+        fullScreenDisplay.style.removeProperty("--full-screen-scroll-duration");
+        fullScreenTextGap.style.removeProperty("height");
+        fullScreenTextClone.textContent = "";
+
+        if (
+          !fullScreenDisplay.classList.contains("visible") ||
+          !enableMarquee
+        ) {
+          return;
+        }
+
+        const displayStyles = getComputedStyle(fullScreenDisplay);
+        const availableHeight = Math.floor(
+          fullScreenDisplay.clientHeight -
+            parseFloat(displayStyles.paddingTop) -
+            parseFloat(displayStyles.paddingBottom),
+        );
+        const textHeight = Math.ceil(fullScreenText.getBoundingClientRect().height);
+        const overflows = textHeight > availableHeight + 1;
+        if (!overflows) return;
+
+        const gap = Math.max(48, Math.round(availableHeight * 0.12));
+        const distance = textHeight + gap;
+        const duration = Math.max(12, distance / 30);
+
+        fullScreenTextGap.style.height = `${gap}px`;
+        fullScreenTextClone.textContent = fullScreenText.textContent;
+        fullScreenDisplay.style.setProperty(
+          "--full-screen-scroll-distance",
+          `${distance}px`,
+        );
+        fullScreenDisplay.style.setProperty(
+          "--full-screen-scroll-duration",
+          `${duration}s`,
+        );
+        fullScreenDisplay.classList.add("vertical-scroll-enabled");
+        fullScreenDisplay.classList.add("is-overflowing");
+      }
+
+      function scheduleFullScreenMarquee() {
+        if (fullScreenMeasureFrame)
+          cancelAnimationFrame(fullScreenMeasureFrame);
+        fullScreenMeasureFrame = requestAnimationFrame(() => {
+          fullScreenMeasureFrame = 0;
+          syncFullScreenMarquee();
+        });
       }
 
       function syncOverflowingPhraseButtons() {
@@ -583,15 +722,22 @@
         settings.enableMarquee = !!e.target.checked;
         saveSettings(settings);
         renderPhraseButtons();
+        scheduleFullScreenMarquee();
       });
-      window.addEventListener("resize", scheduleOverflowSync);
+      window.addEventListener("resize", () => {
+        scheduleOverflowSync();
+        scheduleFullScreenMarquee();
+      });
 
       // --- Initial Load ---
       document.addEventListener("DOMContentLoaded", () => {
         updateSettingsUI();
         renderPhraseButtons();
         if (document.fonts && document.fonts.ready) {
-          document.fonts.ready.then(scheduleOverflowSync);
+          document.fonts.ready.then(() => {
+            scheduleOverflowSync();
+            scheduleFullScreenMarquee();
+          });
         }
       });
 

--- a/index.html
+++ b/index.html
@@ -125,7 +125,8 @@
         display: inline-block;
       }
       .phrase-button.marquee-enabled.is-overflowing:hover .phrase-label-track,
-      .phrase-button.marquee-enabled.is-overflowing:focus-visible .phrase-label-track {
+      .phrase-button.marquee-enabled.is-overflowing:focus-visible
+        .phrase-label-track {
         animation-play-state: paused;
       }
       @keyframes phrase-marquee {
@@ -208,7 +209,9 @@
         </button>
       </div>
 
-      <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
+      <div
+        class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between"
+      >
         <h2 class="text-xl font-semibold text-gray-700">Saved Phrases</h2>
         <div class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
           <label
@@ -399,7 +402,7 @@
 
           const gap = Math.max(24, Math.round(labelWrap.clientWidth * 0.12));
           const distance = textWidth + gap;
-          const duration = Math.max(6, Math.min(18, distance / 32));
+          const duration = Math.max(8, distance / 40);
 
           labelClone.textContent = labelText.textContent;
           button.style.setProperty("--marquee-gap", `${gap}px`);


### PR DESCRIPTION
## Summary

This PR improves handling for long text in OmniText.

Changes included:
- add overflow-aware scrolling for long saved-phrase labels
- make long-text scrolling opt-in via a `Scroll long text` setting
- add wrapped vertical auto-scroll for long fullscreen preview text
- add an adjustable scroll speed slider that appears when scrolling is enabled
- preserve wrapped/static behavior when scrolling is off
- respect reduced-motion preferences by disabling animation and falling back to wrapped text
- improve small-screen layout for the header controls

## Notes

- label scrolling and preview scrolling both use the same scroll speed setting
- fullscreen preview now wraps lines and auto-scrolls vertically instead of using a single-line marquee

## Testing

- verified inline script syntax with `node`
- manually reviewed long-text handling logic for saved labels and fullscreen preview

Closes #1
