### PR TITLE
Add browser-native text-to-speech for fullscreen preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,44 @@
         opacity: 1;
         visibility: visible;
       }
+      #fullScreenSpeakButton {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        z-index: 1001;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 9999px;
+        background: rgba(17, 24, 39, 0.7);
+        color: white;
+        padding: 0.65rem 0.95rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        line-height: 1;
+        cursor: pointer;
+        backdrop-filter: blur(10px);
+      }
+      #fullScreenSpeakButton:hover {
+        background: rgba(31, 41, 55, 0.88);
+      }
+      #fullScreenSpeakButton:focus-visible {
+        outline: 2px solid white;
+        outline-offset: 2px;
+      }
+      #fullScreenSpeakButton.hidden {
+        display: none;
+      }
+      #fullScreenSpeakButton .tts-stop-label {
+        display: none;
+      }
+      #fullScreenSpeakButton.is-speaking .tts-speak-label {
+        display: none;
+      }
+      #fullScreenSpeakButton.is-speaking .tts-stop-label {
+        display: inline;
+      }
       #fullScreenTextWrap {
         width: 100%;
         max-width: 100%;
@@ -334,6 +372,16 @@
     </div>
 
     <div id="fullScreenDisplay">
+      <button
+        id="fullScreenSpeakButton"
+        type="button"
+        class="hidden"
+        aria-label="Speak phrase aloud"
+      >
+        <span aria-hidden="true">🔊</span>
+        <span class="tts-speak-label">Speak</span>
+        <span class="tts-stop-label">Stop</span>
+      </button>
       <div id="fullScreenTextWrap">
         <div id="fullScreenTextTrack">
           <span id="fullScreenText" class="break-anywhere"></span>
@@ -362,6 +410,9 @@
       const fullScreenTextClone = document.getElementById(
         "fullScreenTextClone",
       );
+      const fullScreenSpeakButton = document.getElementById(
+        "fullScreenSpeakButton",
+      );
       const clearAllButton = document.getElementById("clearAllButton");
       const sortByUseToggle = document.getElementById("sortByUseToggle");
       const showUsageToggle = document.getElementById("showUsageToggle");
@@ -369,6 +420,10 @@
       const scrollSpeedControls = document.getElementById("scrollSpeedControls");
       const scrollSpeedSlider = document.getElementById("scrollSpeedSlider");
       const scrollSpeedValue = document.getElementById("scrollSpeedValue");
+      const supportsSpeechSynthesis =
+        "speechSynthesis" in window && "SpeechSynthesisUtterance" in window;
+      let activeUtterance = null;
+      let isSpeaking = false;
       let overflowMeasureFrame = 0;
       let fullScreenMeasureFrame = 0;
 
@@ -430,6 +485,69 @@
           scrollSpeedValue.textContent = getScrollSpeedLabel(scrollSpeed);
         if (scrollSpeedControls)
           scrollSpeedControls.classList.toggle("hidden", !enableMarquee);
+      }
+      function updateSpeakButtonUI() {
+        if (!fullScreenSpeakButton) return;
+        if (!supportsSpeechSynthesis) {
+          fullScreenSpeakButton.classList.add("hidden");
+          return;
+        }
+        fullScreenSpeakButton.classList.toggle(
+          "hidden",
+          !fullScreenDisplay.classList.contains("visible"),
+        );
+        fullScreenSpeakButton.classList.toggle("is-speaking", isSpeaking);
+        fullScreenSpeakButton.setAttribute(
+          "aria-label",
+          isSpeaking ? "Stop speaking" : "Speak phrase aloud",
+        );
+        fullScreenSpeakButton.setAttribute(
+          "title",
+          isSpeaking ? "Stop speaking" : "Speak phrase aloud",
+        );
+      }
+      function stopSpeaking() {
+        if (!supportsSpeechSynthesis) return;
+        if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+          window.speechSynthesis.cancel();
+        }
+        activeUtterance = null;
+        isSpeaking = false;
+        updateSpeakButtonUI();
+      }
+      function speakFullScreenText() {
+        if (!supportsSpeechSynthesis) return;
+        const text = fullScreenText.textContent.trim();
+        if (!text) return;
+
+        window.speechSynthesis.cancel();
+
+        const utterance = new SpeechSynthesisUtterance(text);
+        activeUtterance = utterance;
+        isSpeaking = true;
+        updateSpeakButtonUI();
+
+        utterance.onend = () => {
+          if (activeUtterance !== utterance) return;
+          activeUtterance = null;
+          isSpeaking = false;
+          updateSpeakButtonUI();
+        };
+        utterance.onerror = () => {
+          if (activeUtterance !== utterance) return;
+          activeUtterance = null;
+          isSpeaking = false;
+          updateSpeakButtonUI();
+        };
+
+        window.speechSynthesis.speak(utterance);
+      }
+      function toggleSpeaking() {
+        if (isSpeaking) {
+          stopSpeaking();
+          return;
+        }
+        speakFullScreenText();
       }
 
       // --- Data Access Layer (with migration) ---
@@ -494,13 +612,16 @@
         // bump usage first (so resort reflects immediately if enabled)
         incrementUsage(text);
 
+        stopSpeaking();
         fullScreenText.textContent = text;
         fullScreenDisplay.classList.add("visible");
+        updateSpeakButtonUI();
         scheduleFullScreenMarquee();
       }
 
       /** Hides the full-screen display. */
       function hideFullScreen() {
+        stopSpeaking();
         fullScreenDisplay.classList.remove("visible");
         fullScreenDisplay.classList.remove("measuring-scroll");
         fullScreenDisplay.classList.remove("vertical-scroll-enabled");
@@ -510,6 +631,7 @@
         fullScreenTextGap.style.removeProperty("height");
         fullScreenTextClone.textContent = "";
         fullScreenText.textContent = ""; // Clear text
+        updateSpeakButtonUI();
       }
 
       function syncFullScreenMarquee() {
@@ -762,6 +884,10 @@
       textInput.addEventListener("keypress", (event) => {
         if (event.key === "Enter") addPhrase();
       });
+      fullScreenSpeakButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        toggleSpeaking();
+      });
       fullScreenDisplay.addEventListener("click", hideFullScreen);
       clearAllButton.addEventListener("click", clearAllPhrases);
       sortByUseToggle.addEventListener("change", (e) => {
@@ -800,6 +926,7 @@
       // --- Initial Load ---
       document.addEventListener("DOMContentLoaded", () => {
         updateSettingsUI();
+        updateSpeakButtonUI();
         renderPhraseButtons();
         if (document.fonts && document.fonts.ready) {
           document.fonts.ready.then(() => {
@@ -808,6 +935,7 @@
           });
         }
       });
+      window.addEventListener("pagehide", stopSpeaking);
 
       // --- PWA Service Worker Registration ---
       if ("serviceWorker" in navigator) {

--- a/index.html
+++ b/index.html
@@ -82,8 +82,12 @@
       }
       #fullScreenTextWrap {
         width: 100%;
+        height: 100%;
         max-width: 100%;
         max-height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         overflow: visible;
       }
       #fullScreenTextTrack {
@@ -99,27 +103,19 @@
       #fullScreenTextClone {
         display: none;
       }
-      #fullScreenDisplay.measuring-scroll #fullScreenTextWrap,
-      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextWrap {
-        overflow: hidden;
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing
+        #fullScreenTextWrap {
+        justify-content: flex-start;
+        overflow-x: hidden;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
       }
-      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextTrack {
-        animation: full-screen-vertical-scroll
-          var(--full-screen-scroll-duration, 14s) linear infinite;
-      }
-      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextGap,
-      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextClone {
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing
+        #fullScreenTextGap,
+      #fullScreenDisplay.vertical-scroll-enabled.is-overflowing
+        #fullScreenTextClone {
         display: block;
-      }
-      @keyframes full-screen-vertical-scroll {
-        from {
-          transform: translateY(0);
-        }
-        to {
-          transform: translateY(
-            calc(-1 * var(--full-screen-scroll-distance, 0px))
-          );
-        }
       }
 
       /* Robust long-word wrapping utility */
@@ -217,18 +213,9 @@
         }
       }
       @media (prefers-reduced-motion: reduce) {
-        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextWrap {
-          overflow: visible;
-        }
-        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenTextTrack {
-          animation: none;
-          min-width: 0;
-          display: block;
-          white-space: normal;
-        }
-        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing #fullScreenText {
-          overflow-wrap: anywhere;
-          word-break: break-word;
+        #fullScreenDisplay.vertical-scroll-enabled.is-overflowing
+          #fullScreenTextWrap {
+          justify-content: flex-start;
         }
         #fullScreenTextGap,
         #fullScreenTextClone {
@@ -310,7 +297,9 @@
       >
         <h2 class="text-xl font-semibold text-gray-700">Saved Phrases</h2>
         <div class="flex flex-col gap-3 sm:items-end">
-          <div class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
+          <div
+            class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end"
+          >
             <label
               class="flex items-center gap-2 text-sm text-gray-600"
               title="Sort by most used, then recent"
@@ -337,11 +326,16 @@
             id="scrollSpeedControls"
             class="hidden w-full rounded-lg border border-gray-200 bg-gray-50 p-3 sm:max-w-sm"
           >
-            <div class="flex items-center justify-between gap-3 text-sm text-gray-600">
+            <div
+              class="flex items-center justify-between gap-3 text-sm text-gray-600"
+            >
               <label for="scrollSpeedSlider" class="font-medium text-gray-700">
                 Scroll speed
               </label>
-              <span id="scrollSpeedValue" class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <span
+                id="scrollSpeedValue"
+                class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+              >
                 Normal
               </span>
             </div>
@@ -417,15 +411,27 @@
       const sortByUseToggle = document.getElementById("sortByUseToggle");
       const showUsageToggle = document.getElementById("showUsageToggle");
       const marqueeToggle = document.getElementById("marqueeToggle");
-      const scrollSpeedControls = document.getElementById("scrollSpeedControls");
+      const scrollSpeedControls = document.getElementById(
+        "scrollSpeedControls",
+      );
       const scrollSpeedSlider = document.getElementById("scrollSpeedSlider");
       const scrollSpeedValue = document.getElementById("scrollSpeedValue");
+      const reducedMotionQuery =
+        "matchMedia" in window
+          ? window.matchMedia("(prefers-reduced-motion: reduce)")
+          : null;
       const supportsSpeechSynthesis =
         "speechSynthesis" in window && "SpeechSynthesisUtterance" in window;
       let activeUtterance = null;
       let isSpeaking = false;
       let overflowMeasureFrame = 0;
       let fullScreenMeasureFrame = 0;
+      let fullScreenAutoScrollFrame = 0;
+      let fullScreenAutoScrollResumeTimer = 0;
+      let fullScreenAutoScrollLastTime = 0;
+      let fullScreenLoopDistance = 0;
+      let fullScreenAutoScrollSpeed = 0;
+      let fullScreenIgnoreScrollEventsUntil = 0;
 
       // --- Constants ---
       const STORAGE_KEY = "omniTextPhrases"; // kept same for backwards compatibility
@@ -475,8 +481,12 @@
         const speed = Math.max(1, Math.min(5, Number(scrollSpeed) || 3));
         return 0.7 + (speed - 1) * 0.2;
       }
+      function prefersReducedMotion() {
+        return !!reducedMotionQuery && reducedMotionQuery.matches;
+      }
       function updateSettingsUI() {
-        const { sortByUse, showUsage, enableMarquee, scrollSpeed } = getSettings();
+        const { sortByUse, showUsage, enableMarquee, scrollSpeed } =
+          getSettings();
         if (sortByUseToggle) sortByUseToggle.checked = !!sortByUse;
         if (showUsageToggle) showUsageToggle.checked = !!showUsage;
         if (marqueeToggle) marqueeToggle.checked = !!enableMarquee;
@@ -549,6 +559,92 @@
         }
         speakFullScreenText();
       }
+      function stopFullScreenAutoScroll() {
+        if (fullScreenAutoScrollFrame) {
+          cancelAnimationFrame(fullScreenAutoScrollFrame);
+          fullScreenAutoScrollFrame = 0;
+        }
+        fullScreenAutoScrollLastTime = 0;
+      }
+      function setFullScreenScrollTop(nextScrollTop) {
+        fullScreenIgnoreScrollEventsUntil = Date.now() + 100;
+        fullScreenTextWrap.scrollTop = nextScrollTop;
+      }
+      function clearFullScreenAutoScrollResume() {
+        if (fullScreenAutoScrollResumeTimer) {
+          clearTimeout(fullScreenAutoScrollResumeTimer);
+          fullScreenAutoScrollResumeTimer = 0;
+        }
+      }
+      function normalizeFullScreenScrollPosition() {
+        if (!fullScreenLoopDistance) return;
+        if (fullScreenTextWrap.scrollTop >= fullScreenLoopDistance) {
+          setFullScreenScrollTop(
+            fullScreenTextWrap.scrollTop - fullScreenLoopDistance,
+          );
+        }
+      }
+      function startFullScreenAutoScroll() {
+        clearFullScreenAutoScrollResume();
+        if (
+          !fullScreenDisplay.classList.contains("vertical-scroll-enabled") ||
+          !fullScreenLoopDistance ||
+          !fullScreenAutoScrollSpeed
+        ) {
+          return;
+        }
+        stopFullScreenAutoScroll();
+        const step = (timestamp) => {
+          if (
+            !fullScreenDisplay.classList.contains("vertical-scroll-enabled") ||
+            !fullScreenLoopDistance ||
+            !fullScreenAutoScrollSpeed
+          ) {
+            stopFullScreenAutoScroll();
+            return;
+          }
+          if (!fullScreenAutoScrollLastTime) {
+            fullScreenAutoScrollLastTime = timestamp;
+          }
+          const deltaSeconds =
+            (timestamp - fullScreenAutoScrollLastTime) / 1000;
+          fullScreenAutoScrollLastTime = timestamp;
+
+          let nextScrollTop =
+            fullScreenTextWrap.scrollTop +
+            fullScreenAutoScrollSpeed * deltaSeconds;
+          while (nextScrollTop >= fullScreenLoopDistance) {
+            nextScrollTop -= fullScreenLoopDistance;
+          }
+
+          setFullScreenScrollTop(nextScrollTop);
+
+          fullScreenAutoScrollFrame = requestAnimationFrame(step);
+        };
+        fullScreenAutoScrollFrame = requestAnimationFrame(step);
+      }
+      function queueFullScreenAutoScrollResume(delayMs = 300) {
+        clearFullScreenAutoScrollResume();
+        if (
+          !fullScreenDisplay.classList.contains("vertical-scroll-enabled") ||
+          !fullScreenLoopDistance
+        ) {
+          return;
+        }
+        fullScreenAutoScrollResumeTimer = setTimeout(() => {
+          fullScreenAutoScrollResumeTimer = 0;
+          normalizeFullScreenScrollPosition();
+          startFullScreenAutoScroll();
+        }, delayMs);
+      }
+      function handleFullScreenScrollInteraction(event) {
+        if (!fullScreenDisplay.classList.contains("vertical-scroll-enabled")) {
+          return;
+        }
+        event.stopPropagation();
+        stopFullScreenAutoScroll();
+        queueFullScreenAutoScrollResume();
+      }
 
       // --- Data Access Layer (with migration) ---
       /**
@@ -613,6 +709,9 @@
         incrementUsage(text);
 
         stopSpeaking();
+        clearFullScreenAutoScrollResume();
+        stopFullScreenAutoScroll();
+        setFullScreenScrollTop(0);
         fullScreenText.textContent = text;
         fullScreenDisplay.classList.add("visible");
         updateSpeakButtonUI();
@@ -622,27 +721,32 @@
       /** Hides the full-screen display. */
       function hideFullScreen() {
         stopSpeaking();
+        clearFullScreenAutoScrollResume();
+        stopFullScreenAutoScroll();
         fullScreenDisplay.classList.remove("visible");
-        fullScreenDisplay.classList.remove("measuring-scroll");
         fullScreenDisplay.classList.remove("vertical-scroll-enabled");
         fullScreenDisplay.classList.remove("is-overflowing");
-        fullScreenDisplay.style.removeProperty("--full-screen-scroll-distance");
-        fullScreenDisplay.style.removeProperty("--full-screen-scroll-duration");
         fullScreenTextGap.style.removeProperty("height");
         fullScreenTextClone.textContent = "";
+        fullScreenLoopDistance = 0;
+        fullScreenAutoScrollSpeed = 0;
+        setFullScreenScrollTop(0);
         fullScreenText.textContent = ""; // Clear text
         updateSpeakButtonUI();
       }
 
       function syncFullScreenMarquee() {
         const { enableMarquee, scrollSpeed } = getSettings();
-        fullScreenDisplay.classList.remove("measuring-scroll");
+        const previousLoopDistance = fullScreenLoopDistance;
+        const previousScrollTop = fullScreenTextWrap.scrollTop;
+        clearFullScreenAutoScrollResume();
+        stopFullScreenAutoScroll();
         fullScreenDisplay.classList.remove("vertical-scroll-enabled");
         fullScreenDisplay.classList.remove("is-overflowing");
-        fullScreenDisplay.style.removeProperty("--full-screen-scroll-distance");
-        fullScreenDisplay.style.removeProperty("--full-screen-scroll-duration");
         fullScreenTextGap.style.removeProperty("height");
         fullScreenTextClone.textContent = "";
+        fullScreenLoopDistance = 0;
+        fullScreenAutoScrollSpeed = 0;
 
         if (
           !fullScreenDisplay.classList.contains("visible") ||
@@ -657,7 +761,9 @@
             parseFloat(displayStyles.paddingTop) -
             parseFloat(displayStyles.paddingBottom),
         );
-        const textHeight = Math.ceil(fullScreenText.getBoundingClientRect().height);
+        const textHeight = Math.ceil(
+          fullScreenText.getBoundingClientRect().height,
+        );
         const overflows = textHeight > availableHeight + 1;
         if (!overflows) return;
 
@@ -665,21 +771,24 @@
         const distance = textHeight + gap;
         const duration = Math.max(
           7,
-          (distance / 50) / getScrollSpeedFactor(scrollSpeed),
+          distance / 50 / getScrollSpeedFactor(scrollSpeed),
         );
+        const currentOffset = previousLoopDistance
+          ? previousScrollTop % previousLoopDistance
+          : 0;
+
+        fullScreenDisplay.classList.add("vertical-scroll-enabled");
+        fullScreenDisplay.classList.add("is-overflowing");
+        if (prefersReducedMotion()) {
+          return;
+        }
 
         fullScreenTextGap.style.height = `${gap}px`;
         fullScreenTextClone.textContent = fullScreenText.textContent;
-        fullScreenDisplay.style.setProperty(
-          "--full-screen-scroll-distance",
-          `${distance}px`,
-        );
-        fullScreenDisplay.style.setProperty(
-          "--full-screen-scroll-duration",
-          `${duration}s`,
-        );
-        fullScreenDisplay.classList.add("vertical-scroll-enabled");
-        fullScreenDisplay.classList.add("is-overflowing");
+        fullScreenLoopDistance = distance;
+        fullScreenAutoScrollSpeed = distance / duration;
+        setFullScreenScrollTop(Math.min(currentOffset, distance - 1));
+        startFullScreenAutoScroll();
       }
 
       function scheduleFullScreenMarquee() {
@@ -721,7 +830,7 @@
           const distance = textWidth + gap;
           const duration = Math.max(
             6,
-            (distance / 40) / getScrollSpeedFactor(scrollSpeed),
+            distance / 40 / getScrollSpeedFactor(scrollSpeed),
           );
 
           labelClone.textContent = labelText.textContent;
@@ -888,6 +997,31 @@
         event.stopPropagation();
         toggleSpeaking();
       });
+      fullScreenTextWrap.addEventListener(
+        "pointerdown",
+        handleFullScreenScrollInteraction,
+      );
+      fullScreenTextWrap.addEventListener(
+        "wheel",
+        handleFullScreenScrollInteraction,
+        {
+          passive: true,
+        },
+      );
+      fullScreenTextWrap.addEventListener(
+        "touchstart",
+        handleFullScreenScrollInteraction,
+        { passive: true },
+      );
+      fullScreenTextWrap.addEventListener("scroll", (event) => {
+        if (
+          Date.now() < fullScreenIgnoreScrollEventsUntil ||
+          !fullScreenDisplay.classList.contains("vertical-scroll-enabled")
+        ) {
+          return;
+        }
+        handleFullScreenScrollInteraction(event);
+      });
       fullScreenDisplay.addEventListener("click", hideFullScreen);
       clearAllButton.addEventListener("click", clearAllPhrases);
       sortByUseToggle.addEventListener("change", (e) => {
@@ -922,6 +1056,16 @@
         scheduleOverflowSync();
         scheduleFullScreenMarquee();
       });
+      if (reducedMotionQuery) {
+        if (typeof reducedMotionQuery.addEventListener === "function") {
+          reducedMotionQuery.addEventListener(
+            "change",
+            scheduleFullScreenMarquee,
+          );
+        } else if (typeof reducedMotionQuery.addListener === "function") {
+          reducedMotionQuery.addListener(scheduleFullScreenMarquee);
+        }
+      }
 
       // --- Initial Load ---
       document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary

This PR adds browser-native text-to-speech support to the fullscreen preview in OmniText.

Changes included:
- add a `Speak` / `Stop` button in the fullscreen preview corner
- use browser-native `speechSynthesis` with no external dependency
- hide the TTS control entirely when the browser does not support it
- cancel speech when the preview closes or the page is hidden
- improve long preview text behavior so users can manually scroll to keep up with speech
- make preview auto-scroll pause on user interaction and resume after a short idle delay
- preserve manual scrolling for reduced-motion users and avoid JS auto-scroll in that mode
- keep the existing long-text scroll controls and speed settings working with the preview

## Behavior

- the TTS button only appears in supported browsers
- tapping `Speak` reads the currently displayed fullscreen text aloud
- tapping again changes the control to `Stop` and cancels speech
- long preview text can still auto-scroll when enabled
- if the user manually scrolls the preview, auto-scroll pauses and then resumes from the current position

## Notes

- TTS uses the browser and device voice engine, so voice quality and availability vary by platform
- speech timing is not perfectly synced to preview scrolling, but the preview is now manually adjustable so users can match it as needed
- reduced-motion users keep manual scrolling without forced auto-scroll

## Testing

- verified inline script syntax with `node`
- reviewed TTS support detection and fullscreen state handling
- reviewed preview auto-scroll pause/resume and reduced-motion fallback logic

Closes #2
